### PR TITLE
Feature: setup tailwindcss & storybook

### DIFF
--- a/apps/frontend-web/.storybook/main.js
+++ b/apps/frontend-web/.storybook/main.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   core: { builder: 'webpack5' },
-  stories: ['../../../packages/ui-*/src/*.stories.tsx'],
+  stories: ['../../../packages/ui-*/src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
     '@storybook/addon-essentials',
     '@nrwl/react/plugins/storybook',

--- a/apps/frontend-web/.storybook/preview.js
+++ b/apps/frontend-web/.storybook/preview.js
@@ -1,0 +1,1 @@
+import './tailwind-imports.css';

--- a/apps/frontend-web/.storybook/tailwind-imports.css
+++ b/apps/frontend-web/.storybook/tailwind-imports.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/frontend-web/pages/index.tsx
+++ b/apps/frontend-web/pages/index.tsx
@@ -2,9 +2,12 @@ import { Button } from '@test-assessment/ui-components';
 
 export function Index() {
   return (
-    <Button onClick={() => alert('This is demo button')}>
-      This is test button
-    </Button>
+    <>
+      <p className="text-danger">testing tailwind functionality</p>
+      <Button onClick={() => alert('This is demo button')}>
+        This is test button
+      </Button>
+    </>
   );
 }
 

--- a/apps/frontend-web/tailwind.config.js
+++ b/apps/frontend-web/tailwind.config.js
@@ -1,1 +1,13 @@
-module.exports = require('@test-assessment/ui-theme/tailwind.config');
+const { createGlobPatternsForDependencies } = require('@nrwl/react/tailwind');
+const { join } = require('path');
+
+module.exports = {
+  presets: [require('@test-assessment/ui-theme/tailwind.config')],
+  content: [
+    join(
+      __dirname,
+      '{src,pages,components}/**/*!(*.stories|*.spec).{ts,tsx,html}'
+    ),
+    ...createGlobPatternsForDependencies(__dirname),
+  ],
+};

--- a/packages/ui-components/src/components/Icon.stories.tsx
+++ b/packages/ui-components/src/components/Icon.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Icon from './Icon';
+
+const meta: Meta<typeof Icon> = {
+  title: 'Icon',
+  component: Icon,
+};
+
+export default meta;
+type Story = StoryObj<typeof Icon>;
+
+export const ArrowDown: Story = {
+  render: () => (
+    <Icon name="arrowDown" width={24} height={24} color="text-[#7B5F8B]" />
+  ),
+};

--- a/packages/ui-components/src/components/Icon/index.tsx
+++ b/packages/ui-components/src/components/Icon/index.tsx
@@ -1,0 +1,40 @@
+import { paths } from './paths';
+
+interface Props {
+  name: string;
+  width: number;
+  height: number;
+  color?: string;
+  viewBox?: string;
+  onClick?: () => void;
+}
+
+const Icon = ({
+  name,
+  width,
+  height,
+  viewBox = '0 0 24 24',
+  color,
+  onClick,
+}: Props) => {
+  const svgStyle =
+    paths[name].type === 'stroke'
+      ? { stroke: 'currentColor', fill: 'none' }
+      : { fill: 'currentColor' };
+
+  return (
+    <div className="px-12 bg-danger" onClick={onClick}>
+      <svg
+        width={width}
+        height={height}
+        viewBox={viewBox}
+        style={svgStyle}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        {paths[name].path}
+      </svg>
+    </div>
+  );
+};
+
+export default Icon;

--- a/packages/ui-components/src/components/Icon/paths.tsx
+++ b/packages/ui-components/src/components/Icon/paths.tsx
@@ -1,0 +1,18 @@
+interface IPath {
+  [key: string]: { type: 'stroke' | 'fill'; path: React.ReactNode };
+}
+
+export const paths: IPath = {
+  arrowDown: {
+    type: 'stroke',
+    path: (
+      <path
+        d="M6 9.5L12 15.5L18 9.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    ),
+  },
+};

--- a/packages/ui-theme/tailwind.config.js
+++ b/packages/ui-theme/tailwind.config.js
@@ -1,6 +1,7 @@
 const tokens = require('./src/tokens/example.token.json');
 
 module.exports = {
+  mode: 'jit',
   darkMode: 'class',
   theme: {
     extend: {


### PR DESCRIPTION
### Jira link

- https://datisan.atlassian.net/browse/XDLD-244

### What does this PR do?
- Setup up tailwind for `frontend-web` with tailwind config file from `ui-theme`
- Setup storybook to work with tailwind
- Config to show up stories from `ui-*` repo in storybook

### AFTER 

<img width="1505" alt="image" src="https://user-images.githubusercontent.com/29749097/230934776-d15292b3-e8e9-48ac-8936-e61c6af2f61f.png">




<img width="881" alt="image" src="https://user-images.githubusercontent.com/29749097/230933543-c6c80d64-ea9c-4eec-9170-c4cc85d1b428.png">
